### PR TITLE
getter methods added to format dates

### DIFF
--- a/models/Reaction.js
+++ b/models/Reaction.js
@@ -19,7 +19,8 @@ const reactionSchema = new Schema({
     },
     createdAt: {
         type: Date,
-        default: Date.now(),
+        default: Date.now,
+        get: (date) => date.toLocaleString(),
     }
 },
 {

--- a/models/Thought.js
+++ b/models/Thought.js
@@ -15,7 +15,8 @@ const thoughtSchema = new Schema({
     },
     createdAt: {
         type: Date,
-        default: Date.now(),
+        default: Date.now,
+        get: (date) => date.toLocaleString(),
     },
     username: {
         type: String,
@@ -24,6 +25,7 @@ const thoughtSchema = new Schema({
     reactions: [reactionSchema],
 },
 {
+    tiemstamps: true,
     toJSON: {
       getters: true,
     },

--- a/models/Thought.js
+++ b/models/Thought.js
@@ -25,7 +25,6 @@ const thoughtSchema = new Schema({
     reactions: [reactionSchema],
 },
 {
-    tiemstamps: true,
     toJSON: {
       getters: true,
     },


### PR DESCRIPTION
Getter methods have been added to the "Created At" fields of the Thought model and reaction schema.  The getter method uses the .toLocaleString() method to format all dates and times.